### PR TITLE
Install Knative Kafka and run simple tests (no TLS/SASL)

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export EVENTING_NAMESPACE="${EVENTING_NAMESPACE:-knative-eventing}"
-export TEST_EVENTING_NAMESPACE=$EVENTING_NAMESPACE
+export SYSTEM_NAMESPACE=$EVENTING_NAMESPACE
 export KNATIVE_DEFAULT_NAMESPACE=$EVENTING_NAMESPACE
 export ZIPKIN_NAMESPACE=$EVENTING_NAMESPACE
 export CONFIG_TRACING_CONFIG="test/config/config-tracing.yaml"
@@ -10,14 +10,8 @@ export STRIMZI_INSTALLATION_CONFIG="$(mktemp)"
 export KAFKA_INSTALLATION_CONFIG="test/config/100-kafka-ephemeral-triple-2.6.0.yaml"
 export KAFKA_USERS_CONFIG="test/config/100-strimzi-users-0.20.0.yaml"
 export KAFKA_PLAIN_CLUSTER_URL="my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
-KAFKA_CLUSTER_URL=${KAFKA_PLAIN_CLUSTER_URL}
-# Namespace where we install Eventing components
-export SYSTEM_NAMESPACE="knative-eventing"
-
-# Zipkin setup
 readonly KNATIVE_EVENTING_MONITORING_YAML="test/config/monitoring.yaml"
-
-
+KAFKA_CLUSTER_URL=${KAFKA_PLAIN_CLUSTER_URL}
 
 function scale_up_workers(){
   local cluster_api_ns="openshift-machine-api"
@@ -188,8 +182,8 @@ function run_e2e_tests(){
   the source tests REQUIRE the secrets, hence we create it here:
   create_auth_secrets || return 1
 
-  oc get ns ${TEST_EVENTING_NAMESPACE} 2>/dev/null || TEST_EVENTING_NAMESPACE="knative-eventing"
-  sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${TEST_EVENTING_NAMESPACE}/g" ${CONFIG_TRACING_CONFIG} | oc replace -f -
+  oc get ns ${SYSTEM_NAMESPACE} 2>/dev/null || SYSTEM_NAMESPACE="knative-eventing"
+  sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${CONFIG_TRACING_CONFIG} | oc replace -f -
   local test_name="${1:-}"
   local run_command=""
   local failed=0

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -1,7 +1,23 @@
 #!/usr/bin/env bash
 
 export EVENTING_NAMESPACE="${EVENTING_NAMESPACE:-knative-eventing}"
+export TEST_EVENTING_NAMESPACE=$EVENTING_NAMESPACE
+export KNATIVE_DEFAULT_NAMESPACE=$EVENTING_NAMESPACE
 export ZIPKIN_NAMESPACE=$EVENTING_NAMESPACE
+export CONFIG_TRACING_CONFIG="test/config/config-tracing.yaml"
+export STRIMZI_INSTALLATION_CONFIG_TEMPLATE="test/config/100-strimzi-cluster-operator-0.20.0.yaml"
+export STRIMZI_INSTALLATION_CONFIG="$(mktemp)"
+export KAFKA_INSTALLATION_CONFIG="test/config/100-kafka-ephemeral-triple-2.6.0.yaml"
+export KAFKA_USERS_CONFIG="test/config/100-strimzi-users-0.20.0.yaml"
+export KAFKA_PLAIN_CLUSTER_URL="my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
+KAFKA_CLUSTER_URL=${KAFKA_PLAIN_CLUSTER_URL}
+# Namespace where we install Eventing components
+export SYSTEM_NAMESPACE="knative-eventing"
+
+# Zipkin setup
+readonly KNATIVE_EVENTING_MONITORING_YAML="test/config/monitoring.yaml"
+
+
 
 function scale_up_workers(){
   local cluster_api_ns="openshift-machine-api"
@@ -47,82 +63,28 @@ function timeout() {
   return 0
 }
 
-function install_tracing {
-  deploy_zipkin
-  enable_eventing_tracing
+# Setup zipkin
+function install_tracing() {
+  echo "Installing Zipkin..."
+  kubectl apply -f "${KNATIVE_EVENTING_MONITORING_YAML}"
+  wait_until_pods_running knative-eventing || return 1
+  # Setup config tracing for tracing tests
+  kubectl apply -f "${CONFIG_TRACING_CONFIG}"
 }
 
-function deploy_zipkin {
-  logger.info "Installing Zipkin in namespace ${ZIPKIN_NAMESPACE}"
-  cat <<EOF | oc apply -f - || return $?
-apiVersion: v1
-kind: Service
-metadata:
-  name: zipkin
-  namespace: ${ZIPKIN_NAMESPACE}
-spec:
-  type: NodePort
-  ports:
-  - name: http
-    port: 9411
-  selector:
-    app: zipkin
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: zipkin
-  namespace: ${ZIPKIN_NAMESPACE}
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: zipkin
-  template:
-    metadata:
-      labels:
-        app: zipkin
-      annotations:
-        sidecar.istio.io/inject: "false"
-    spec:
-      containers:
-      - name: zipkin
-        image: docker.io/openzipkin/zipkin:2.13.0
-        ports:
-        - containerPort: 9411
-        env:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        resources:
-          limits:
-            memory: 1000Mi
-          requests:
-            memory: 256Mi
----
-EOF
+function install_strimzi(){
+  header "Installing Kafka cluster"
+  oc create namespace kafka || return 1
+  sed 's/namespace: .*/namespace: kafka/' ${STRIMZI_INSTALLATION_CONFIG_TEMPLATE} > ${STRIMZI_INSTALLATION_CONFIG}
+  oc apply -f "${STRIMZI_INSTALLATION_CONFIG}" -n kafka || return 1
+  # Wait for the CRD we need to actually be active
+  oc wait crd --timeout=900s kafkas.kafka.strimzi.io --for=condition=Established || return 1
 
-  logger.info "Waiting until Zipkin is available"
-  oc wait deployment --all --timeout=600s --for=condition=Available -n ${ZIPKIN_NAMESPACE} || return 1
-}
+  oc apply -f ${KAFKA_INSTALLATION_CONFIG} -n kafka
+  oc wait kafka --all --timeout=900s --for=condition=Ready -n kafka || return 1
 
-function enable_eventing_tracing {
-  header "Configuring tracing for Eventing"
-
-  cat <<EOF | oc apply -f - || return $?
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-tracing
-  namespace: ${EVENTING_NAMESPACE}
-data:
-  enable: "true"
-  zipkin-endpoint: "http://zipkin.${ZIPKIN_NAMESPACE}.svc.cluster.local:9411/api/v2/spans"
-  sample-rate: "1.0"
-  debug: "true"
-EOF
+  # Create some Strimzi Kafka Users
+  oc apply -f "${KAFKA_USERS_CONFIG}" -n kafka || return 1
 }
 
 function install_serverless(){
@@ -150,4 +112,97 @@ function install_knative_eventing(){
   # Wait for 5 pods to appear first
   timeout 900 '[[ $(oc get pods -n $EVENTING_NAMESPACE --no-headers | wc -l) -lt 5 ]]' || return 1
   wait_until_pods_running $EVENTING_NAMESPACE || return 1
+}
+
+function install_knative_kafka {
+  install_knative_kafka_channel || return 1
+  install_knative_kafka_source || return 1
+}
+
+function install_knative_kafka_channel(){
+  header "Installing Knative Kafka Channel"
+
+  RELEASE_YAML="openshift/release/knative-eventing-kafka-channel-ci.yaml"
+
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-consolidated-controller|${IMAGE_FORMAT//\$\{component\}/knative-eventing-kafka-consolidated-controller}|g" ${RELEASE_YAML}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-consolidated-dispatcher|${IMAGE_FORMAT//\$\{component\}/knative-eventing-kafka-consolidated-dispatcher}|g" ${RELEASE_YAML}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-webhook|${IMAGE_FORMAT//\$\{component\}/knative-eventing-kafka-webhook}|g"                                 ${RELEASE_YAML}
+
+  cat ${RELEASE_YAML} \
+  | sed "s/REPLACE_WITH_CLUSTER_URL/${KAFKA_CLUSTER_URL}/" \
+  | oc apply --filename -
+
+  wait_until_pods_running $EVENTING_NAMESPACE || return 1
+}
+
+function install_knative_kafka_source(){
+  header "Installing Knative Kafka Source"
+
+  RELEASE_YAML="openshift/release/knative-eventing-kafka-source-ci.yaml"
+
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-source-controller|${IMAGE_FORMAT//\$\{component\}/knative-eventing-kafka-source-controller}|g"   ${RELEASE_YAML}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-receive-adapter|${IMAGE_FORMAT//\$\{component\}/knative-eventing-kafka-receive-adapter}|g"       ${RELEASE_YAML}
+
+  cat ${RELEASE_YAML} \
+  | oc apply --filename -
+
+  wait_until_pods_running $EVENTING_NAMESPACE || return 1
+}
+
+function create_auth_secrets() {
+  create_tls_secrets
+  create_sasl_secrets
+}
+
+function create_tls_secrets() {
+  header "Creating TLS Kafka secret"
+  STRIMZI_CRT=$(oc -n kafka get secret my-cluster-cluster-ca-cert --template='{{index .data "ca.crt"}}' | base64 --decode )
+  TLSUSER_CRT=$(oc -n kafka get secret my-tls-user --template='{{index .data "user.crt"}}' | base64 --decode )
+  TLSUSER_KEY=$(oc -n kafka get secret my-tls-user --template='{{index .data "user.key"}}' | base64 --decode )
+
+  sleep 10
+
+  oc create secret --namespace knative-eventing generic strimzi-tls-secret \
+    --from-literal=ca.crt="$STRIMZI_CRT" \
+    --from-literal=user.crt="$TLSUSER_CRT" \
+    --from-literal=user.key="$TLSUSER_KEY" || return 1
+}
+
+function create_sasl_secrets() {
+  header "Creating SASL Kafka secret"
+  STRIMZI_CRT=$(oc -n kafka get secret my-cluster-cluster-ca-cert --template='{{index .data "ca.crt"}}' | base64 --decode )
+  SASL_PASSWD=$(oc -n kafka get secret my-sasl-user --template='{{index .data "password"}}' | base64 --decode )
+
+  sleep 10
+
+  oc create secret --namespace knative-eventing generic strimzi-sasl-secret \
+    --from-literal=ca.crt="$STRIMZI_CRT" \
+    --from-literal=password="$SASL_PASSWD" \
+    --from-literal=saslType="SCRAM-SHA-512" \
+    --from-literal=user="my-sasl-user" || return 1
+}
+
+function run_e2e_tests(){
+  header "Testing the KafkaChannel with no AUTH"
+
+  the source tests REQUIRE the secrets, hence we create it here:
+  create_auth_secrets || return 1
+
+  oc get ns ${TEST_EVENTING_NAMESPACE} 2>/dev/null || TEST_EVENTING_NAMESPACE="knative-eventing"
+  sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${TEST_EVENTING_NAMESPACE}/g" ${CONFIG_TRACING_CONFIG} | oc replace -f -
+  local test_name="${1:-}"
+  local run_command=""
+  local failed=0
+  local channels=messaging.knative.dev/v1beta1:KafkaChannel
+
+  local common_opts=" -channels=$channels --kubeconfig $KUBECONFIG" ## --imagetemplate $TEST_IMAGE_TEMPLATE"
+  if [ -n "$test_name" ]; then
+      local run_command="-run ^(${test_name})$"
+  fi
+
+  go_test_e2e -tags=e2e,source -timeout=90m -parallel=12 ./test/e2e \
+    "$run_command" \
+    $common_opts --dockerrepo "quay.io/openshift-knative" --tag "v0.18" || failed=$?
+
+  return $failed
 }

--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -6,8 +6,7 @@ source "$(dirname "$0")/e2e-common.sh"
 
 set -Eeuox pipefail
 
-# FIX ME:
-export TEST_IMAGE_TEMPLATE="${IMAGE_FORMAT//\$\{component\}/knative-eventing-test-{{.Name}}}"
+export TEST_IMAGE_TEMPLATE="${IMAGE_FORMAT//\$\{component\}/knative-eventing-kafka-test-{{.Name}}}"
 
 env
 
@@ -15,11 +14,17 @@ scale_up_workers || exit 1
 
 failed=0
 
+(( !failed )) && install_strimzi || failed=1
+
 (( !failed )) && install_serverless || failed=1
 
 (( !failed )) && install_knative_eventing || failed=1
 
+(( !failed )) && install_knative_kafka || failed=1
+
 (( !failed )) && install_tracing || failed=1
+
+(( !failed )) && run_e2e_tests || failed=1
 
 (( failed )) && dump_cluster_state
 

--- a/test/config/100-kafka-ephemeral-triple-2.6.0.yaml
+++ b/test/config/100-kafka-ephemeral-triple-2.6.0.yaml
@@ -28,6 +28,7 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       log.message.format.version: "2.6"
+      auto.create.topics.enable: false
     storage:
       type: ephemeral
   zookeeper:


### PR DESCRIPTION
TLS/SASL will follow in a new PR 

We need this, so that we can actually bump the serverless operator w/ the 0.19.1 kafkas ....

