### PR TITLE
Adding more OCP specific files for the master stash

### DIFF
--- a/openshift/ci-operator/generate-ci-config.sh
+++ b/openshift/ci-operator/generate-ci-config.sh
@@ -79,6 +79,7 @@ for img in $core_images; do
   to_image=$(echo ${image_base//[_.]/-})
   to_image=$(echo ${to_image//v0/upgrade-v0})
   to_image=$(echo ${to_image//migrate/storage-version-migration})
+  to_image=$(echo ${to_image//kafka-kafka-/kafka-})
   cat <<EOF
 - dockerfile_path: openshift/ci-operator/knative-images/$image_base/Dockerfile
   from: base

--- a/openshift/ci-operator/knative-images/source_controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/source_controller/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM openshift/origin-base
+
+ADD source_controller /usr/bin/source_controller
+ENTRYPOINT ["/usr/bin/source_controller"]

--- a/openshift/ci-operator/update-ci.sh
+++ b/openshift/ci-operator/update-ci.sh
@@ -7,7 +7,7 @@ fail() { echo; echo "$*"; exit 1; }
 
 # Deduce X.Y.Z version from branch name
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
-VERSION=$(echo $BRANCH | sed -E 's/^.*([0-9]+\.[0-9]+\.[0-9]+)|.*/\1/')
+VERSION=$(echo $BRANCH | sed -E 's/^.*(v[0-9]+\.[0-9]+\.[0-9]+|next)|.*/\1/')
 test -n "$VERSION" || fail "'$BRANCH' is not a release branch"
 VER=$(echo $VERSION | sed 's/\./_/;s/\.[0-9]\+$//') # X_Y form of version
 
@@ -15,12 +15,12 @@ VER=$(echo $VERSION | sed 's/\./_/;s/\.[0-9]\+$//') # X_Y form of version
 # Set up variables for important locations in the openshift/release repo.
 OPENSHIFT=$(realpath "$1"); shift
 test -d "$OPENSHIFT/.git" || fail "'$OPENSHIFT' is not a git repo"
-MIRROR="$OPENSHIFT/core-services/image-mirroring/knative/mapping_knative_v${VER}_quay"
+MIRROR="$OPENSHIFT/core-services/image-mirroring/knative/mapping_knative_${VER}_quay"
 CONFIGDIR=$OPENSHIFT/ci-operator/config/openshift-knative/eventing-kafka
 test -d "$CONFIGDIR" || fail "'$CONFIGDIR' is not a directory"
 
 # Generate CI config files
-CONFIG=$CONFIGDIR/openshift-knative-eventing-kafka-release-v$VERSION
+CONFIG=$CONFIGDIR/openshift-knative-eventing-kafka-release-$VERSION
 CURDIR=$(dirname $0)
 $CURDIR/generate-ci-config.sh knative-$VERSION 4.6 > ${CONFIG}__46.yaml
 $CURDIR/generate-ci-config.sh knative-$VERSION 4.7 true > ${CONFIG}__47.yaml

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
 
 export EVENTING_NAMESPACE="${EVENTING_NAMESPACE:-knative-eventing}"
+export SYSTEM_NAMESPACE=$EVENTING_NAMESPACE
+export KNATIVE_DEFAULT_NAMESPACE=$EVENTING_NAMESPACE
 export ZIPKIN_NAMESPACE=$EVENTING_NAMESPACE
+export CONFIG_TRACING_CONFIG="test/config/config-tracing.yaml"
+export STRIMZI_INSTALLATION_CONFIG_TEMPLATE="test/config/100-strimzi-cluster-operator-0.20.0.yaml"
+export STRIMZI_INSTALLATION_CONFIG="$(mktemp)"
+export KAFKA_INSTALLATION_CONFIG="test/config/100-kafka-ephemeral-triple-2.6.0.yaml"
+export KAFKA_USERS_CONFIG="test/config/100-strimzi-users-0.20.0.yaml"
+export KAFKA_PLAIN_CLUSTER_URL="my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
+readonly KNATIVE_EVENTING_MONITORING_YAML="test/config/monitoring.yaml"
+KAFKA_CLUSTER_URL=${KAFKA_PLAIN_CLUSTER_URL}
 
 function scale_up_workers(){
   local cluster_api_ns="openshift-machine-api"
@@ -47,82 +57,28 @@ function timeout() {
   return 0
 }
 
-function install_tracing {
-  deploy_zipkin
-  enable_eventing_tracing
+# Setup zipkin
+function install_tracing() {
+  echo "Installing Zipkin..."
+  kubectl apply -f "${KNATIVE_EVENTING_MONITORING_YAML}"
+  wait_until_pods_running knative-eventing || return 1
+  # Setup config tracing for tracing tests
+  kubectl apply -f "${CONFIG_TRACING_CONFIG}"
 }
 
-function deploy_zipkin {
-  logger.info "Installing Zipkin in namespace ${ZIPKIN_NAMESPACE}"
-  cat <<EOF | oc apply -f - || return $?
-apiVersion: v1
-kind: Service
-metadata:
-  name: zipkin
-  namespace: ${ZIPKIN_NAMESPACE}
-spec:
-  type: NodePort
-  ports:
-  - name: http
-    port: 9411
-  selector:
-    app: zipkin
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: zipkin
-  namespace: ${ZIPKIN_NAMESPACE}
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: zipkin
-  template:
-    metadata:
-      labels:
-        app: zipkin
-      annotations:
-        sidecar.istio.io/inject: "false"
-    spec:
-      containers:
-      - name: zipkin
-        image: docker.io/openzipkin/zipkin:2.13.0
-        ports:
-        - containerPort: 9411
-        env:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        resources:
-          limits:
-            memory: 1000Mi
-          requests:
-            memory: 256Mi
----
-EOF
+function install_strimzi(){
+  header "Installing Kafka cluster"
+  oc create namespace kafka || return 1
+  sed 's/namespace: .*/namespace: kafka/' ${STRIMZI_INSTALLATION_CONFIG_TEMPLATE} > ${STRIMZI_INSTALLATION_CONFIG}
+  oc apply -f "${STRIMZI_INSTALLATION_CONFIG}" -n kafka || return 1
+  # Wait for the CRD we need to actually be active
+  oc wait crd --timeout=900s kafkas.kafka.strimzi.io --for=condition=Established || return 1
 
-  logger.info "Waiting until Zipkin is available"
-  oc wait deployment --all --timeout=600s --for=condition=Available -n ${ZIPKIN_NAMESPACE} || return 1
-}
+  oc apply -f ${KAFKA_INSTALLATION_CONFIG} -n kafka
+  oc wait kafka --all --timeout=900s --for=condition=Ready -n kafka || return 1
 
-function enable_eventing_tracing {
-  header "Configuring tracing for Eventing"
-
-  cat <<EOF | oc apply -f - || return $?
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-tracing
-  namespace: ${EVENTING_NAMESPACE}
-data:
-  enable: "true"
-  zipkin-endpoint: "http://zipkin.${ZIPKIN_NAMESPACE}.svc.cluster.local:9411/api/v2/spans"
-  sample-rate: "1.0"
-  debug: "true"
-EOF
+  # Create some Strimzi Kafka Users
+  oc apply -f "${KAFKA_USERS_CONFIG}" -n kafka || return 1
 }
 
 function install_serverless(){
@@ -150,4 +106,97 @@ function install_knative_eventing(){
   # Wait for 5 pods to appear first
   timeout 900 '[[ $(oc get pods -n $EVENTING_NAMESPACE --no-headers | wc -l) -lt 5 ]]' || return 1
   wait_until_pods_running $EVENTING_NAMESPACE || return 1
+}
+
+function install_knative_kafka {
+  install_knative_kafka_channel || return 1
+  install_knative_kafka_source || return 1
+}
+
+function install_knative_kafka_channel(){
+  header "Installing Knative Kafka Channel"
+
+  RELEASE_YAML="openshift/release/knative-eventing-kafka-channel-ci.yaml"
+
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-consolidated-controller|${IMAGE_FORMAT//\$\{component\}/knative-eventing-kafka-consolidated-controller}|g" ${RELEASE_YAML}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-consolidated-dispatcher|${IMAGE_FORMAT//\$\{component\}/knative-eventing-kafka-consolidated-dispatcher}|g" ${RELEASE_YAML}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-webhook|${IMAGE_FORMAT//\$\{component\}/knative-eventing-kafka-webhook}|g"                                 ${RELEASE_YAML}
+
+  cat ${RELEASE_YAML} \
+  | sed "s/REPLACE_WITH_CLUSTER_URL/${KAFKA_CLUSTER_URL}/" \
+  | oc apply --filename -
+
+  wait_until_pods_running $EVENTING_NAMESPACE || return 1
+}
+
+function install_knative_kafka_source(){
+  header "Installing Knative Kafka Source"
+
+  RELEASE_YAML="openshift/release/knative-eventing-kafka-source-ci.yaml"
+
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-source-controller|${IMAGE_FORMAT//\$\{component\}/knative-eventing-kafka-source-controller}|g"   ${RELEASE_YAML}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-receive-adapter|${IMAGE_FORMAT//\$\{component\}/knative-eventing-kafka-receive-adapter}|g"       ${RELEASE_YAML}
+
+  cat ${RELEASE_YAML} \
+  | oc apply --filename -
+
+  wait_until_pods_running $EVENTING_NAMESPACE || return 1
+}
+
+function create_auth_secrets() {
+  create_tls_secrets
+  create_sasl_secrets
+}
+
+function create_tls_secrets() {
+  header "Creating TLS Kafka secret"
+  STRIMZI_CRT=$(oc -n kafka get secret my-cluster-cluster-ca-cert --template='{{index .data "ca.crt"}}' | base64 --decode )
+  TLSUSER_CRT=$(oc -n kafka get secret my-tls-user --template='{{index .data "user.crt"}}' | base64 --decode )
+  TLSUSER_KEY=$(oc -n kafka get secret my-tls-user --template='{{index .data "user.key"}}' | base64 --decode )
+
+  sleep 10
+
+  oc create secret --namespace knative-eventing generic strimzi-tls-secret \
+    --from-literal=ca.crt="$STRIMZI_CRT" \
+    --from-literal=user.crt="$TLSUSER_CRT" \
+    --from-literal=user.key="$TLSUSER_KEY" || return 1
+}
+
+function create_sasl_secrets() {
+  header "Creating SASL Kafka secret"
+  STRIMZI_CRT=$(oc -n kafka get secret my-cluster-cluster-ca-cert --template='{{index .data "ca.crt"}}' | base64 --decode )
+  SASL_PASSWD=$(oc -n kafka get secret my-sasl-user --template='{{index .data "password"}}' | base64 --decode )
+
+  sleep 10
+
+  oc create secret --namespace knative-eventing generic strimzi-sasl-secret \
+    --from-literal=ca.crt="$STRIMZI_CRT" \
+    --from-literal=password="$SASL_PASSWD" \
+    --from-literal=saslType="SCRAM-SHA-512" \
+    --from-literal=user="my-sasl-user" || return 1
+}
+
+function run_e2e_tests(){
+  header "Testing the KafkaChannel with no AUTH"
+
+  # the source tests REQUIRE the secrets, hence we create it here:
+  create_auth_secrets || return 1
+
+  oc get ns ${SYSTEM_NAMESPACE} 2>/dev/null || SYSTEM_NAMESPACE="knative-eventing"
+  sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${CONFIG_TRACING_CONFIG} | oc replace -f -
+  local test_name="${1:-}"
+  local run_command=""
+  local failed=0
+  local channels=messaging.knative.dev/v1beta1:KafkaChannel
+
+  local common_opts=" -channels=$channels --kubeconfig $KUBECONFIG" ## --imagetemplate $TEST_IMAGE_TEMPLATE"
+  if [ -n "$test_name" ]; then
+      local run_command="-run ^(${test_name})$"
+  fi
+
+  go_test_e2e -tags=e2e,source -timeout=90m -parallel=12 ./test/e2e \
+    "$run_command" \
+    $common_opts --dockerrepo "quay.io/openshift-knative" --tag "v0.18" || failed=$?
+
+  return $failed
 }

--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -6,8 +6,7 @@ source "$(dirname "$0")/e2e-common.sh"
 
 set -Eeuox pipefail
 
-# FIX ME:
-export TEST_IMAGE_TEMPLATE="${IMAGE_FORMAT//\$\{component\}/knative-eventing-test-{{.Name}}}"
+export TEST_IMAGE_TEMPLATE="${IMAGE_FORMAT//\$\{component\}/knative-eventing-kafka-test-{{.Name}}}"
 
 env
 
@@ -15,11 +14,17 @@ scale_up_workers || exit 1
 
 failed=0
 
+(( !failed )) && install_strimzi || failed=1
+
 (( !failed )) && install_serverless || failed=1
 
 (( !failed )) && install_knative_eventing || failed=1
 
+(( !failed )) && install_knative_kafka || failed=1
+
 (( !failed )) && install_tracing || failed=1
+
+(( !failed )) && run_e2e_tests || failed=1
 
 (( failed )) && dump_cluster_state
 

--- a/openshift/release/knative-eventing-kafka-channel-ci.yaml
+++ b/openshift/release/knative-eventing-kafka-channel-ci.yaml
@@ -1,0 +1,672 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kafka-addressable-resolver
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+    duck.knative.dev/addressable: "true"
+rules:
+  - apiGroups:
+      - messaging.knative.dev
+    resources:
+      - kafkachannels
+      - kafkachannels/status
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kafka-channelable-manipulator
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+    duck.knative.dev/channelable: "true"
+rules:
+  - apiGroups:
+      - messaging.knative.dev
+    resources:
+      - kafkachannels
+      - kafkachannels/status
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kafka-ch-controller
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+rules:
+  - apiGroups:
+      - messaging.knative.dev
+    resources:
+      - kafkachannels
+      - kafkachannels/status
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      - messaging.knative.dev
+    resources:
+      - kafkachannels/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - "" # Core API group.
+    resources:
+      - services
+      - configmaps
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+  - apiGroups:
+      - "" # Core API group.
+    resources:
+      - services
+    verbs: &everything
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - "" # Core API Group.
+    resources:
+      - configmaps
+    resourceNames:
+      - kafka-ch-dispatcher
+    verbs:
+      - update
+  - apiGroups:
+      - "" # Core API Group.
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "" # Core API group.
+    resources:
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - deployments/status
+    verbs: *everything
+  - apiGroups:
+      - "" # Core API group.
+    resources:
+      - serviceaccounts
+    verbs: *everything
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+    verbs: *everything
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs: *everything
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kafka-ch-controller
+  namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kafka-ch-dispatcher
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+rules:
+  - apiGroups:
+      - messaging.knative.dev
+    resources:
+      - kafkachannels
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      - messaging.knative.dev
+    resources:
+      - kafkachannels/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - "" # Core API group.
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - messaging.knative.dev
+    resources:
+      - kafkachannels
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "" # Core API Group.
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kafka-ch-dispatcher
+  namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kafka-webhook
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "configmaps"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - ""
+    resources:
+      - "secrets"
+    verbs:
+      - "get"
+      - "create"
+      - "list"
+      - "watch"
+      - "update"
+  - apiGroups:
+      - "apps"
+    resources:
+      - "deployments"
+    verbs:
+      - "get"
+  - apiGroups:
+      - "apps"
+    resources:
+      - "deployments/finalizers"
+    verbs:
+      - update
+  - apiGroups:
+      - "admissionregistration.k8s.io"
+    resources:
+      - "mutatingwebhookconfigurations"
+      - "validatingwebhookconfigurations"
+    verbs: &everything
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
+  - apiGroups:
+      - "messaging.knative.dev"
+    resources:
+      - "kafkachannels"
+      - "kafkachannels/status"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - "leases"
+    verbs: *everything
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - "customresourcedefinitions"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kafka-webhook
+  namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kafka-ch-controller
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+subjects:
+  - kind: ServiceAccount
+    name: kafka-ch-controller
+    namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: kafka-ch-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kafka-ch-dispatcher
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+subjects:
+  - kind: ServiceAccount
+    name: kafka-ch-dispatcher
+    namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: kafka-ch-dispatcher
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kafka-webhook
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+subjects:
+  - kind: ServiceAccount
+    name: kafka-webhook
+    namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: kafka-webhook
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkachannels.messaging.knative.dev
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+    knative.dev/crd-install: "true"
+    messaging.knative.dev/subscribable: "true"
+    duck.knative.dev/addressable: "true"
+spec:
+  group: messaging.knative.dev
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  names:
+    kind: KafkaChannel
+    plural: kafkachannels
+    singular: kafkachannel
+    categories:
+    - all
+    - knative
+    - messaging
+    - channel
+    shortNames:
+    - kc
+  scope: Namespaced
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+    - name: Ready
+      type: string
+      JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    - name: URL
+      type: string
+      JSONPath: .status.address.url
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  conversion:
+    strategy: Webhook
+    conversionReviewVersions: ["v1beta1", "v1alpha1"]
+    webhookClientConfig:
+      service:
+        name: kafka-webhook
+        namespace: knative-eventing
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-kafka
+  namespace: knative-eventing
+data:
+  bootstrapServers: REPLACE_WITH_CLUSTER_URL
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-leader-election-kafka
+  namespace: knative-eventing
+data:
+  resourceLock: "leases"
+  leaseDuration: "15s"
+  renewDeadline: "10s"
+  retryPeriod: "2s"
+  _example: |
+    resourceLock: "leases"
+    leaseDuration: "15s"
+    renewDeadline: "10s"
+    retryPeriod: "2s"
+    enabledComponents: "kafkachannel-dispatcher,kafkachannel-controller"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-webhook
+  namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+    role: kafka-webhook
+spec:
+  ports:
+    - name: https-webhook
+      port: 443
+      targetPort: 8443
+  selector:
+    role: kafka-webhook
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka-ch-controller
+  namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+spec:
+  replicas: 1
+  selector:
+    matchLabels: &labels
+      messaging.knative.dev/channel: kafka-channel
+      messaging.knative.dev/role: controller
+  template:
+    metadata:
+      labels: *labels
+    spec:
+      serviceAccountName: kafka-ch-controller
+      containers:
+      - name: controller
+        image: registry.svc.ci.openshift.org/openshift/knative-v0.19.1:knative-eventing-kafka-consolidated-controller
+        env:
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: METRICS_DOMAIN
+          value: knative.dev/eventing
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: CONFIG_LEADERELECTION_NAME
+          value: config-leader-election-kafka
+        - name: DISPATCHER_IMAGE
+          value: registry.svc.ci.openshift.org/openshift/knative-v0.19.1:knative-eventing-kafka-consolidated-dispatcher
+        ports:
+        - containerPort: 9090
+          name: metrics
+        volumeMounts:
+        - name: config-logging
+          mountPath: /etc/config-logging
+      volumes:
+      - name: config-logging
+        configMap:
+          name: config-logging
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka-ch-dispatcher
+  namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      messaging.knative.dev/channel: kafka-channel
+      messaging.knative.dev/role: dispatcher
+  template:
+    metadata:
+      labels:
+        messaging.knative.dev/channel: kafka-channel
+        messaging.knative.dev/role: dispatcher
+        contrib.eventing.knative.dev/release: v0.19.1
+    spec:
+      containers:
+      - name: dispatcher
+        image: registry.svc.ci.openshift.org/openshift/knative-v0.19.1:knative-eventing-kafka-consolidated-dispatcher
+        env:
+        - name: SYSTEM_NAMESPACE
+          value: ''
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: METRICS_DOMAIN
+          value: "knative.dev/eventing"
+        - name: CONFIG_LOGGING_NAME
+          value: "config-logging"
+        - name: CONFIG_LEADERELECTION_NAME
+          value: "config-leader-election-kafka"
+        - name: CONTAINER_NAME
+          value: dispatcher
+        ports:
+        - containerPort: 9090
+          name: metrics
+          protocol: TCP
+        volumeMounts:
+        - name: config-kafka
+          mountPath: /etc/config-kafka
+      serviceAccountName: kafka-ch-dispatcher
+      volumes:
+      - name: config-kafka
+        configMap:
+          name: config-kafka
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    messaging.knative.dev/channel: kafka-channel
+    messaging.knative.dev/role: dispatcher
+  name: kafka-ch-dispatcher
+  namespace: knative-eventing
+spec:
+  ports:
+  - name: http-dispatcher
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    messaging.knative.dev/channel: kafka-channel
+    messaging.knative.dev/role: dispatcher
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: defaulting.webhook.kafka.messaging.knative.dev
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: kafka-webhook
+      namespace: knative-eventing
+  failurePolicy: Fail
+  name: defaulting.webhook.kafka.messaging.knative.dev
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validation.webhook.kafka.messaging.knative.dev
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: kafka-webhook
+      namespace: knative-eventing
+  failurePolicy: Fail
+  name: validation.webhook.kafka.messaging.knative.dev
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: messaging-webhook-certs
+  namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka-webhook
+  namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+spec:
+  replicas: 1
+  selector:
+    matchLabels: &labels
+      app: kafka-webhook
+      role: kafka-webhook
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels: *labels
+    spec:
+      serviceAccountName: kafka-webhook
+      containers:
+      - name: kafka-webhook
+        terminationMessagePolicy: FallbackToLogsOnError
+        image: registry.svc.ci.openshift.org/openshift/knative-v0.19.1:knative-eventing-kafka-webhook
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: METRICS_DOMAIN
+          value: knative.dev/eventing
+        - name: WEBHOOK_NAME
+          value: kafka-webhook
+        - name: WEBHOOK_PORT
+          value: "8443"
+        ports:
+        - name: https-webhook
+          containerPort: 8443
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+        readinessProbe: &probe
+          periodSeconds: 1
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: "webhook"
+        livenessProbe:
+          <<: *probe
+          initialDelaySeconds: 20
+      terminationGracePeriodSeconds: 300

--- a/openshift/release/knative-eventing-kafka-distributed-channel-ci.yaml
+++ b/openshift/release/knative-eventing-kafka-distributed-channel-ci.yaml
@@ -1,0 +1,439 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: eventing-kafka-addressable-resolver
+  labels:
+    eventing.knative.dev/release: devel
+    duck.knative.dev/addressable: "true"
+rules:
+- apiGroups:
+  - messaging.knative.dev
+  resources:
+  - kafkachannels
+  - kafkachannels/status
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    duck.knative.dev/channelable: "true"
+    kafka.eventing.knative.dev/release: devel
+  name: kafka-channelable-manipulator
+rules:
+- apiGroups:
+  - messaging.knative.dev
+  resources:
+  - kafkachannels
+  - kafkachannels/status
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eventing-kafka-channel-controller
+  namespace: knative-eventing
+  labels:
+    kafka.eventing.knative.dev/release: devel
+subjects:
+- kind: ServiceAccount
+  name: eventing-kafka-channel-controller
+  namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: eventing-kafka-channel-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: eventing-kafka-channel-controller
+  labels:
+    kafka.eventing.knative.dev/release: devel
+rules:
+- apiGroups:
+  - "" # Core API Group
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - "" # Core API Group.
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - messaging.knative.dev
+  resources:
+  - channels
+  - channels/status
+  - subscriptions
+  - subscriptions/status
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - messaging.knative.dev
+  resources:
+  - kafkachannels
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - messaging.knative.dev
+  resources:
+  - kafkachannels/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: eventing-kafka-channel-controller
+  namespace: knative-eventing
+  labels:
+    kafka.eventing.knative.dev/release: devel
+subjects:
+- kind: ServiceAccount
+  name: eventing-kafka-channel-controller
+  namespace: knative-eventing
+roleRef:
+  kind: Role
+  name: eventing-kafka-channel-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: eventing-kafka-channel-controller
+  namespace: knative-eventing
+  labels:
+    kafka.eventing.knative.dev/release: devel
+rules:
+- apiGroups:
+  - "" # Core API Group
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eventing-kafka-channel-controller
+  namespace: knative-eventing
+  labels:
+    kafka.eventing.knative.dev/release: devel
+---
+apiVersion: v1
+data:
+  sarama: |
+    Version: 2.0.0 # Kafka Version Compatibility From Sarama's Supported List (Major.Minor.Patch)
+    Admin:
+      Timeout: 10000000000  # 10 seconds
+    Net:
+      KeepAlive: 30000000000  # 30 seconds
+      MaxOpenRequests: 1 # Set to 1 for use with Idempotent Producer
+      TLS:
+        Enable: true
+      SASL:
+        Enable: true
+        Mechanism: PLAIN
+        Version: 1
+    Metadata:
+      RefreshFrequency: 300000000000  # 5 minutes
+    Consumer:
+      Offsets:
+        AutoCommit:
+          Interval: 5000000000  # 5 seconds
+        Retention: 604800000000000  # 1 week
+    Producer:
+      Idempotent: true  # Must be false for Azure EventHubs
+      RequiredAcks: -1  # -1 = WaitForAll, Most stringent option for "at-least-once" delivery.
+  eventing-kafka: |
+    receiver:
+      cpuLimit: 200m
+      cpuRequest: 100m
+      memoryLimit: 100Mi
+      memoryRequest: 50Mi
+      replicas: 1
+    dispatcher:
+      cpuLimit: 500m
+      cpuRequest: 300m
+      memoryLimit: 128Mi
+      memoryRequest: 50Mi
+      replicas: 1
+    kafka:
+      enableSaramaLogging: false
+      topic:
+        defaultNumPartitions: 4
+        defaultReplicationFactor: 1 # Cannot exceed the number of Kafka Brokers!
+        defaultRetentionMillis: 604800000  # 1 week
+      adminType: kafka # One of "kafka", "azure", "custom"
+kind: ConfigMap
+metadata:
+  name: config-eventing-kafka
+  namespace: knative-eventing
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkachannels.messaging.knative.dev
+  labels:
+    kafka.eventing.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+    messaging.knative.dev/subscribable: "true"
+    duck.knative.dev/addressable: "true"
+spec:
+  group: messaging.knative.dev
+  names:
+    kind: KafkaChannel
+    plural: kafkachannels
+    singular: kafkachannel
+    categories:
+    - all
+    - knative
+    - messaging
+    - channel
+    shortNames:
+    - kc
+  scope: Namespaced
+  subresources:
+    status: { }
+  additionalPrinterColumns:
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+  - name: URL
+    type: string
+    JSONPath: .status.address.url
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            numPartitions:
+              format: int32
+              type: integer
+              description: "Number of partitions of a Kafka topic."
+            replicationFactor:
+              format: int16
+              type: integer
+              description: "Replication factor of a Kafka topic."
+            subscribable:
+              type: object
+              properties:
+                subscribers:
+                  type: array
+                  description: "The list of subscribers that have expressed interest in receiving events from this channel."
+                  items:
+                    required:
+                    - uid
+                    properties:
+                      ref:
+                        type: object
+                        required:
+                        - namespace
+                        - name
+                        - uid
+                        properties:
+                          apiVersion:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                            minLength: 1
+                          namespace:
+                            type: string
+                            minLength: 1
+                          uid:
+                            type: string
+                            minLength: 1
+                      uid:
+                        type: string
+                        minLength: 1
+                      subscriberURI:
+                        type: string
+                        minLength: 1
+                      replyURI:
+                        type: string
+                        minLength: 1
+  versions:
+  - name: v1alpha1
+    served: false # Disabled Until We Include The Conversion Webhook From... eventing-contrib/kafka/channel/cmd/webhook
+    storage: false
+  - name: v1beta1
+    served: true
+    storage: true
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-leader-election-kafkachannel
+  namespace: knative-eventing
+data:
+  resourceLock: "leases"
+  leaseDuration: "15s"
+  renewDeadline: "10s"
+  retryPeriod: "2s"
+  _example: |
+    resourceLock: "leases"
+    leaseDuration: "15s"
+    renewDeadline: "10s"
+    retryPeriod: "2s"
+    enabledComponents: "kafkachannel-controller, kafkasecret-controller"
+---
+apiVersion: v1
+data:
+  brokers: ""
+  namespace: ""
+  password: ""
+  username: ""
+kind: Secret
+metadata:
+  name: kafka-cluster
+  namespace: knative-eventing
+  labels:
+    eventing-kafka.knative.dev/kafka-secret: "true"
+type: Opaque
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: eventing-kafka-channel-controller
+  namespace: knative-eventing
+  labels:
+    k8s-app: eventing-kafka-channel-controller
+    kafka.eventing.knative.dev/release: devel
+spec:
+  selector:
+    app: eventing-kafka-channel-controller
+  ports:
+  - name: metrics
+    protocol: TCP
+    port: 8081
+    targetPort: 8081
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: eventing-kafka-channel-controller
+  namespace: knative-eventing
+  labels:
+    app: eventing-kafka-channel-controller
+    kafka.eventing.knative.dev/release: devel
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: eventing-kafka-channel-controller
+      name: eventing-kafka-channel-controller
+  template:
+    metadata:
+      labels:
+        app: eventing-kafka-channel-controller
+        name: eventing-kafka-channel-controller
+    spec:
+      serviceAccountName: eventing-kafka-channel-controller
+      containers:
+      - name: eventing-kafka
+        image: registry.svc.ci.openshift.org/openshift/knative-v0.19.1:knative-eventing-kafka-distributed-controller
+        imagePullPolicy: IfNotPresent # Must be IfNotPresent or Never if used with ko.local
+        ports:
+        - containerPort: 8081
+          name: metrics
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_LEADERELECTION_NAME
+          value: config-leader-election-kafkachannel
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: METRICS_PORT
+          value: "8081"
+        - name: METRICS_DOMAIN
+          value: "eventing-kafka"
+        - name: RECEIVER_IMAGE
+          value: "registry.svc.ci.openshift.org/openshift/knative-v0.19.1:knative-eventing-kafka-receiver"
+        - name: DISPATCHER_IMAGE
+          value: "registry.svc.ci.openshift.org/openshift/knative-v0.19.1:knative-eventing-kafka-distributed-dispatcher"
+        resources:
+          requests:
+            cpu: 20m
+            memory: 25Mi
+          limits:
+            cpu: 100m
+            memory: 50Mi

--- a/openshift/release/knative-eventing-kafka-source-ci.yaml
+++ b/openshift/release/knative-eventing-kafka-source-ci.yaml
@@ -1,0 +1,572 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kafka-controller-manager
+  namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: eventing-sources-kafka-controller
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+rules:
+- apiGroups:
+  - sources.knative.dev
+  resources:
+  - kafkasources
+  - kafkasources/finalizers
+  verbs: &everything
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - sources.knative.dev
+  resources:
+  - kafkasources/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - bindings.knative.dev
+  resources:
+  - kafkabindings
+  - kafkabindings/finalizers
+  verbs: &everything
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - bindings.knative.dev
+  resources:
+  - kafkabindings/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs: *everything
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - events
+  - configmaps
+  - secrets
+  verbs: *everything
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - create
+  - update
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs: *everything
+- apiGroups:
+  - "admissionregistration.k8s.io"
+  resources:
+  - "mutatingwebhookconfigurations"
+  - "validatingwebhookconfigurations"
+  verbs: &everything
+  - "get"
+  - "list"
+  - "create"
+  - "update"
+  - "delete"
+  - "patch"
+  - "watch"
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - "customresourcedefinitions"
+  verbs:
+  - "get"
+  - "list"
+  - "create"
+  - "update"
+  - "delete"
+  - "patch"
+  - "watch"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: eventing-kafka-source-observer
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+    duck.knative.dev/source: "true"
+rules:
+- apiGroups:
+  - "sources.knative.dev"
+  resources:
+  - "kafkasources"
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eventing-sources-kafka-controller
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+subjects:
+- kind: ServiceAccount
+  name: kafka-controller-manager
+  namespace: knative-eventing
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: eventing-sources-kafka-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eventing-sources-kafka-controller-addressable-resolver
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+subjects:
+- kind: ServiceAccount
+  name: kafka-controller-manager
+  namespace: knative-eventing
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: addressable-resolver
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eventing-sources-kafka-controller-podspecable-binding
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+subjects:
+- kind: ServiceAccount
+  name: kafka-controller-manager
+  namespace: knative-eventing
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: podspecable-binding
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+    duck.knative.dev/binding: "true"
+    knative.dev/crd-install: "true"
+  name: kafkabindings.bindings.knative.dev
+spec:
+  group: bindings.knative.dev
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  names:
+    categories:
+    - all
+    - knative
+    - eventing
+    - bindings
+    kind: KafkaBinding
+    plural: kafkabindings
+  scope: Namespaced
+  subresources:
+    status: {}
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: kafka-source-webhook
+        namespace: knative-eventing
+  additionalPrinterColumns:
+    - name: BootstrapServers
+      type: string
+      JSONPath: ".spec.bootstrapServers"
+    - name: Ready
+      type: string
+      JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+    eventing.knative.dev/source: "true"
+    duck.knative.dev/source: "true"
+    knative.dev/crd-install: "true"
+  annotations:
+    registry.knative.dev/eventTypes: |
+      [
+        { "type": "dev.knative.kafka.event" }
+      ]
+  name: kafkasources.sources.knative.dev
+spec:
+  group: sources.knative.dev
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  names:
+    categories:
+    - all
+    - knative
+    - eventing
+    - sources
+    kind: KafkaSource
+    plural: kafkasources
+  scope: Namespaced
+  subresources:
+    status: {}
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: kafka-source-webhook
+        namespace: knative-eventing
+  additionalPrinterColumns:
+    - name: Topics
+      type: string
+      JSONPath: ".spec.topics"
+    - name: BootstrapServers
+      type: string
+      JSONPath: ".spec.bootstrapServers"
+    - name: Ready
+      type: string
+      JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-controller
+  namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+    control-plane: kafka-controller-manager
+spec:
+  selector:
+    control-plane: kafka-controller-manager
+  ports:
+  - name: https-kafka
+    port: 443
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka-controller-manager
+  namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+    control-plane: kafka-controller-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels: &labels
+      control-plane: kafka-controller-manager
+  template:
+    metadata:
+      labels: *labels
+    spec:
+      serviceAccountName: kafka-controller-manager
+      containers:
+      - name: manager
+        image: registry.svc.ci.openshift.org/openshift/knative-v0.19.1:knative-eventing-kafka-source-controller
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: METRICS_DOMAIN
+          value: knative.dev/sources
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: CONFIG_LEADERELECTION_NAME
+          value: config-leader-election-kafka
+        - name: KAFKA_RA_IMAGE
+          value: registry.svc.ci.openshift.org/openshift/knative-v0.19.1:knative-eventing-kafka-receive-adapter
+        volumeMounts:
+        resources:
+          requests:
+            cpu: 20m
+            memory: 20Mi
+        readinessProbe: &probe
+          periodSeconds: 1
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: "webhook"
+        livenessProbe:
+          <<: *probe
+          initialDelaySeconds: 20
+      serviceAccount: kafka-controller-manager
+      terminationGracePeriodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    role: webhook
+    contrib.eventing.knative.dev/release: v0.19.1
+  name: kafka-source-webhook
+  namespace: knative-eventing
+spec:
+  ports:
+  - name: https-webhook
+    port: 443
+    targetPort: 8443
+  selector:
+    control-plane: kafka-controller-manager
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: defaulting.webhook.kafka.sources.knative.dev
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: kafka-source-webhook
+      namespace: knative-eventing
+  failurePolicy: Fail
+  name: defaulting.webhook.kafka.sources.knative.dev
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: kafkabindings.webhook.kafka.sources.knative.dev
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: kafka-source-webhook
+      namespace: knative-eventing
+  failurePolicy: Fail
+  name: kafkabindings.webhook.kafka.sources.knative.dev
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validation.webhook.kafka.sources.knative.dev
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: kafka-source-webhook
+      namespace: knative-eventing
+  failurePolicy: Fail
+  name: validation.webhook.kafka.sources.knative.dev
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: config.webhook.kafka.sources.knative.dev
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: kafka-source-webhook
+      namespace: knative-eventing
+  failurePolicy: Fail
+  name: config.webhook.kafka.sources.knative.dev
+  namespaceSelector:
+    matchExpressions:
+    - key: contrib.eventing.knative.dev/release
+      operator: Exists
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kafka-source-webhook-certs
+  namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-leader-election-kafka
+  namespace: knative-eventing
+data:
+  resourceLock: "leases"
+  leaseDuration: "15s"
+  renewDeadline: "10s"
+  retryPeriod: "2s"
+  _example: |
+    resourceLock: "leases"
+    leaseDuration: "15s"
+    renewDeadline: "10s"
+    retryPeriod: "2s"
+    enabledComponents: "kafka-controller"
+---
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-logging
+  namespace: knative-eventing
+data:
+  zap-logger-config: |
+    {
+      "level": "info",
+      "development": false,
+      "outputPaths": ["stdout"],
+      "errorOutputPaths": ["stderr"],
+      "encoding": "json",
+      "encoderConfig": {
+        "timeKey": "ts",
+        "levelKey": "level",
+        "nameKey": "logger",
+        "callerKey": "caller",
+        "messageKey": "msg",
+        "stacktraceKey": "stacktrace",
+        "lineEnding": "",
+        "levelEncoder": "",
+        "timeEncoder": "iso8601",
+        "durationEncoder": "",
+        "callerEncoder": ""
+      }
+    }
+  loglevel.controller: "info"
+  loglevel.webhook: "info"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: knative-eventing
+data:
+  _example: |
+    logging.enable-var-log-collection: false
+    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-output-config: |
+      <filter **>
+        @type parser
+        key_name log
+        <parse>
+          @type multi_format
+          <pattern>
+            format json
+            time_key fluentd-time # fluentd-time is reserved for structured logs
+            time_format %Y-%m-%dT%H:%M:%S.%NZ
+          </pattern>
+          <pattern>
+            format none
+            message_key log
+          </pattern>
+        </parse>
+      </filter>
+      <match **>
+        @id elasticsearch
+        @type elasticsearch
+        @log_level info
+        include_tag_key true
+        host elasticsearch-logging.knative-monitoring
+        port 9200
+        logstash_format true
+        <buffer>
+          @type file
+          path /var/log/fluentd-buffers/kubernetes.system.buffer
+          flush_mode interval
+          retry_type exponential_backoff
+          flush_thread_count 2
+          flush_interval 5s
+          retry_forever
+          retry_max_interval 30
+          chunk_limit_size 2M
+          queue_limit_length 8
+          overflow_action block
+        </buffer>
+      </match>
+    logging.revision-url-template: |
+      http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))
+    logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
+    metrics.backend-destination: prometheus
+    metrics.request-metrics-backend-destination: prometheus
+    metrics.stackdriver-project-id: "<your stackdriver project id>"
+    metrics.allow-stackdriver-custom-metrics: "false"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-tracing
+  namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: v0.19.1
+    knative.dev/config-propagation: original
+    knative.dev/config-category: eventing
+data:
+  _example: |
+    backend: "none"
+    zipkin-endpoint: "http://zipkin.istio-system.svc.cluster.local:9411/api/v2/spans"
+    stackdriver-project-id: "my-project"
+    debug: "false"
+    sample-rate: "0.1"

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -20,11 +20,13 @@ function resolve_resources(){
     # 4. Remove empty lines
     sed -e "s+\(.* image: \)\(knative.dev\)\(.*/\)\(test/\)\(.*\)+\1\2 \3\4test-\5+g" \
         -e "s+ko://++" \
+        -e "s+knative-sources+knative-eventing+" \
+        -e "s+contrib.eventing.knative.dev/release: devel+contrib.eventing.knative.dev/release: ${release}+" \
         -e "s+knative.dev/eventing-kafka/cmd/source/receive_adapter+${image_prefix}receive-adapter${image_tag}+" \
         -e "s+knative.dev/eventing-kafka/cmd/source/controller+${image_prefix}source-controller${image_tag}+" \
         -e "s+knative.dev/eventing-kafka/cmd/channel/consolidated/controller+${image_prefix}consolidated-controller${image_tag}+" \
         -e "s+knative.dev/eventing-kafka/cmd/channel/consolidated/dispatcher+${image_prefix}consolidated-dispatcher${image_tag}+" \
-        -e "s+knative.dev/eventing-kafka/cmd/webhook+${image_prefix}channel-webhook${image_tag}+" \
+        -e "s+knative.dev/eventing-kafka/cmd/webhook+${image_prefix}webhook${image_tag}+" \
         -e "s+knative.dev/eventing-kafka/cmd/channel/distributed/controller+${image_prefix}distributed-controller${image_tag}+" \
         -e "s+knative.dev/eventing-kafka/cmd/channel/distributed/receiver+${image_prefix}receiver${image_tag}+" \
         -e "s+knative.dev/eventing-kafka/cmd/channel/distributed/dispatcher+${image_prefix}distributed-dispatcher${image_tag}+" \


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

MASTER is used as `stash` (like on our other forks), and we have now CI enabled on the `019.1` branch. This copies those files here, so we have them, on our master stash.

