### PR TITLE
[0.19] Update ci script generator

### DIFF
--- a/openshift/ci-operator/update-ci.sh
+++ b/openshift/ci-operator/update-ci.sh
@@ -25,6 +25,26 @@ CURDIR=$(dirname $0)
 $CURDIR/generate-ci-config.sh knative-$VERSION 4.6 > ${CONFIG}__46.yaml
 $CURDIR/generate-ci-config.sh knative-$VERSION 4.7 true > ${CONFIG}__47.yaml
 
+# Append missing lines to the mirror file.
+VER=$(echo $VERSION | sed 's/\./_/;s/\.[0-9]\+$//') # X_Y form of version
+MIRROR="$OPENSHIFT/core-services/image-mirroring/knative/mapping_knative_${VER}_quay"
+[ -n "$(tail -c1 $MIRROR)" ] && echo >> $MIRROR # Make sure there's a newline
+test_images=$(find ./openshift/ci-operator/knative-test-images -mindepth 1 -maxdepth 1 -type d | LC_COLLATE=posix sort)
+for IMAGE in $test_images; do
+    NAME=knative-eventing-kafka-test-$(basename $IMAGE | sed 's/_/-/' | sed 's/_/-/' | sed 's/[_.]/-/' | sed 's/[_.]/-/' | sed 's/v0/upgrade-v0/')
+
+    echo "Adding $NAME to mirror file as $VERSION tag"
+    LINE="registry.ci.openshift.org/openshift/knative-$VERSION:$NAME quay.io/openshift-knative/${NAME/knative-eventing-kafka-test-/}:$VERSION"
+    # Add $LINE if not already present
+    grep -q "^$LINE\$" $MIRROR || echo "$LINE"  >> $MIRROR
+
+    VER=$(echo $VER | sed 's/\_/./')
+    echo "Adding $NAME to mirror file as $VER tag"
+    LINE="registry.ci.openshift.org/openshift/knative-$VERSION:$NAME quay.io/openshift-knative/${NAME/knative-eventing-kafka-test-/}:$VER"
+    # Add $LINE if not already present
+    grep -q "^$LINE\$" $MIRROR || echo "$LINE"  >> $MIRROR
+done
+
 # Switch to openshift/release to generate PROW files
 cd $OPENSHIFT
 echo "Generating PROW files in $OPENSHIFT"

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -196,7 +196,7 @@ function run_e2e_tests(){
 
   go_test_e2e -tags=e2e,source -timeout=90m -parallel=12 ./test/e2e \
     "$run_command" \
-    $common_opts --dockerrepo "quay.io/openshift-knative" --tag "v0.18" || failed=$?
+    $common_opts --dockerrepo "quay.io/openshift-knative" --tag "v0.19" || failed=$?
 
   return $failed
 }


### PR DESCRIPTION
* use new 0.19 images (well, newly added to mirror)
* Adding logic to update the "mirror" file for openshift/releaes repo's quay_io mirror