### PR TITLE
Registry update 0.20.0

### DIFF
--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -9,10 +9,10 @@ channel_output_file="openshift/release/knative-eventing-kafka-channel-ci.yaml"
 distributed_channel_output_file="openshift/release/knative-eventing-kafka-distributed-channel-ci.yaml"
 
 if [ "$release" == "ci" ]; then
-    image_prefix="registry.svc.ci.openshift.org/openshift/knative-nightly:knative-eventing-kafka-"
+    image_prefix="registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-kafka-"
     tag=""
 else
-    image_prefix="registry.svc.ci.openshift.org/openshift/knative-${release}:knative-eventing-kafka-"
+    image_prefix="registry.ci.openshift.org/openshift/knative-${release}:knative-eventing-kafka-"
     tag=""
 fi
 

--- a/openshift/release/knative-eventing-kafka-channel-ci.yaml
+++ b/openshift/release/knative-eventing-kafka-channel-ci.yaml
@@ -460,7 +460,7 @@ spec:
       serviceAccountName: kafka-ch-controller
       containers:
       - name: controller
-        image: registry.svc.ci.openshift.org/openshift/knative-v0.20.0:knative-eventing-kafka-consolidated-controller
+        image: registry.ci.openshift.org/openshift/knative-v0.20.0:knative-eventing-kafka-consolidated-controller
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging
@@ -477,7 +477,7 @@ spec:
         - name: CONFIG_LEADERELECTION_NAME
           value: config-leader-election
         - name: DISPATCHER_IMAGE
-          value: registry.svc.ci.openshift.org/openshift/knative-v0.20.0:knative-eventing-kafka-consolidated-dispatcher
+          value: registry.ci.openshift.org/openshift/knative-v0.20.0:knative-eventing-kafka-consolidated-dispatcher
         ports:
         - containerPort: 9090
           name: metrics
@@ -511,7 +511,7 @@ spec:
     spec:
       containers:
       - name: dispatcher
-        image: registry.svc.ci.openshift.org/openshift/knative-v0.20.0:knative-eventing-kafka-consolidated-dispatcher
+        image: registry.ci.openshift.org/openshift/knative-v0.20.0:knative-eventing-kafka-consolidated-dispatcher
         env:
         - name: SYSTEM_NAMESPACE
           value: ''
@@ -617,7 +617,7 @@ spec:
       containers:
       - name: kafka-webhook
         terminationMessagePolicy: FallbackToLogsOnError
-        image: registry.svc.ci.openshift.org/openshift/knative-v0.20.0:knative-eventing-kafka-webhook
+        image: registry.ci.openshift.org/openshift/knative-v0.20.0:knative-eventing-kafka-webhook
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/openshift/release/knative-eventing-kafka-distributed-channel-ci.yaml
+++ b/openshift/release/knative-eventing-kafka-distributed-channel-ci.yaml
@@ -468,7 +468,7 @@ spec:
       serviceAccountName: eventing-kafka-channel-controller
       containers:
       - name: eventing-kafka
-        image: registry.svc.ci.openshift.org/openshift/knative-v0.20.0:knative-eventing-kafka-distributed-controller
+        image: registry.ci.openshift.org/openshift/knative-v0.20.0:knative-eventing-kafka-distributed-controller
         imagePullPolicy: IfNotPresent # Must be IfNotPresent or Never if used with ko.local
         ports:
         - containerPort: 8081
@@ -495,9 +495,9 @@ spec:
         - name: METRICS_DOMAIN
           value: "eventing-kafka"
         - name: RECEIVER_IMAGE
-          value: "registry.svc.ci.openshift.org/openshift/knative-v0.20.0:knative-eventing-kafka-receiver"
+          value: "registry.ci.openshift.org/openshift/knative-v0.20.0:knative-eventing-kafka-receiver"
         - name: DISPATCHER_IMAGE
-          value: "registry.svc.ci.openshift.org/openshift/knative-v0.20.0:knative-eventing-kafka-distributed-dispatcher"
+          value: "registry.ci.openshift.org/openshift/knative-v0.20.0:knative-eventing-kafka-distributed-dispatcher"
         resources:
           requests:
             cpu: 20m
@@ -526,7 +526,7 @@ spec:
       containers:
       - name: kafka-webhook
         terminationMessagePolicy: FallbackToLogsOnError
-        image: registry.svc.ci.openshift.org/openshift/knative-v0.20.0:knative-eventing-kafka-webhook
+        image: registry.ci.openshift.org/openshift/knative-v0.20.0:knative-eventing-kafka-webhook
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/openshift/release/knative-eventing-kafka-source-ci.yaml
+++ b/openshift/release/knative-eventing-kafka-source-ci.yaml
@@ -347,7 +347,7 @@ spec:
       serviceAccountName: kafka-controller-manager
       containers:
       - name: manager
-        image: registry.svc.ci.openshift.org/openshift/knative-v0.20.0:knative-eventing-kafka-source-controller
+        image: registry.ci.openshift.org/openshift/knative-v0.20.0:knative-eventing-kafka-source-controller
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -360,7 +360,7 @@ spec:
         - name: CONFIG_LEADERELECTION_NAME
           value: config-leader-election
         - name: KAFKA_RA_IMAGE
-          value: registry.svc.ci.openshift.org/openshift/knative-v0.20.0:knative-eventing-kafka-receive-adapter
+          value: registry.ci.openshift.org/openshift/knative-v0.20.0:knative-eventing-kafka-receive-adapter
         volumeMounts:
         resources:
           requests:


### PR DESCRIPTION
we should be using the `registry.ci.openshift` url...

I noticed this change, b/c the mirror file uses that ....   

I have to admit that for some time both functioned - not knowing which is the correct .... now we know .


This fix prevents docker pull errors 