### PR TITLE
[0.20] More clean up

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -105,9 +105,9 @@ function install_knative_kafka_channel(){
 
   RELEASE_YAML="openshift/release/knative-eventing-kafka-channel-ci.yaml"
 
-  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-consolidated-controller|${IMAGE_FORMAT//\$\{component\}/knative-eventing-kafka-consolidated-controller}|g" ${RELEASE_YAML}
-  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-consolidated-dispatcher|${IMAGE_FORMAT//\$\{component\}/knative-eventing-kafka-consolidated-dispatcher}|g" ${RELEASE_YAML}
-  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-webhook|${IMAGE_FORMAT//\$\{component\}/knative-eventing-kafka-webhook}|g"                                 ${RELEASE_YAML}
+  sed -i -e "s|registry.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-consolidated-controller|${IMAGE_FORMAT//\$\{component\}/knative-eventing-kafka-consolidated-controller}|g" ${RELEASE_YAML}
+  sed -i -e "s|registry.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-consolidated-dispatcher|${IMAGE_FORMAT//\$\{component\}/knative-eventing-kafka-consolidated-dispatcher}|g" ${RELEASE_YAML}
+  sed -i -e "s|registry.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-webhook|${IMAGE_FORMAT//\$\{component\}/knative-eventing-kafka-webhook}|g"                                 ${RELEASE_YAML}
 
   cat ${RELEASE_YAML} \
   | sed "s/REPLACE_WITH_CLUSTER_URL/${KAFKA_CLUSTER_URL}/" \
@@ -121,8 +121,8 @@ function install_knative_kafka_source(){
 
   RELEASE_YAML="openshift/release/knative-eventing-kafka-source-ci.yaml"
 
-  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-source-controller|${IMAGE_FORMAT//\$\{component\}/knative-eventing-kafka-source-controller}|g"   ${RELEASE_YAML}
-  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-receive-adapter|${IMAGE_FORMAT//\$\{component\}/knative-eventing-kafka-receive-adapter}|g"       ${RELEASE_YAML}
+  sed -i -e "s|registry.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-source-controller|${IMAGE_FORMAT//\$\{component\}/knative-eventing-kafka-source-controller}|g"   ${RELEASE_YAML}
+  sed -i -e "s|registry.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-receive-adapter|${IMAGE_FORMAT//\$\{component\}/knative-eventing-kafka-receive-adapter}|g"       ${RELEASE_YAML}
 
   cat ${RELEASE_YAML} \
   | oc apply --filename -

--- a/openshift/release/knative-eventing-kafka-channel-ci.yaml
+++ b/openshift/release/knative-eventing-kafka-channel-ci.yaml
@@ -65,7 +65,6 @@ rules:
   - apiGroups:
       - "" # Core API group.
     resources:
-      - services
       - configmaps
       - secrets
     verbs:
@@ -77,6 +76,7 @@ rules:
       - "" # Core API group.
     resources:
       - services
+      - serviceaccounts
     verbs: &everything
       - get
       - list
@@ -101,17 +101,10 @@ rules:
       - patch
       - update
   - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - "" # Core API group.
     resources:
       - endpoints
+      - pods
     verbs:
       - get
       - list
@@ -121,11 +114,6 @@ rules:
     resources:
       - deployments
       - deployments/status
-    verbs: *everything
-  - apiGroups:
-      - "" # Core API group.
-    resources:
-      - serviceaccounts
     verbs: *everything
   - apiGroups:
       - rbac.authorization.k8s.io
@@ -535,6 +523,9 @@ spec:
         - containerPort: 9090
           name: metrics
           protocol: TCP
+        - containerPort: 8081
+          name: sub-status
+          protocol: TCP
         volumeMounts:
         - name: config-kafka
           mountPath: /etc/config-kafka
@@ -558,6 +549,10 @@ spec:
     port: 80
     protocol: TCP
     targetPort: 8080
+  - name: http-sub-status
+    port: 8081
+    protocol: TCP
+    targetPort: 8081
   selector:
     messaging.knative.dev/channel: kafka-channel
     messaging.knative.dev/role: dispatcher


### PR DESCRIPTION
* regenerating the yamls (missing content, due to backports touched the source... but not the CI generated yamls), via `make RELEASE=v0.20.0 generate-release`
* removing one more of old registry


