### PR TITLE
[0.20] Use CE connection args available, instead of hardcoded values (#440)

### DIFF
--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -150,11 +150,8 @@ func NewDispatcher(ctx context.Context, args *KafkaDispatcherArgs) (*KafkaDispat
 		return nil, fmt.Errorf("unable to create kafka producer against Kafka bootstrap servers %v : %v", args.Brokers, err)
 	}
 
-	// Configured with the same connection arguments of IMC
-	kncloudevents.ConfigureConnectionArgs(&kncloudevents.ConnectionArgs{
-		MaxIdleConns:        1000,
-		MaxIdleConnsPerHost: 100,
-	})
+	// Configure connection arguments
+	kncloudevents.ConfigureConnectionArgs(args.KnCEConnectionArgs)
 
 	dispatcher := &KafkaDispatcher{
 		dispatcher:           eventingchannels.NewMessageDispatcher(logging.FromContext(ctx).Desugar()),

--- a/pkg/channel/consolidated/dispatcher/dispatcher_it_test.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher_it_test.go
@@ -67,10 +67,13 @@ func TestDispatcher(t *testing.T) {
 	})
 
 	dispatcherArgs := KafkaDispatcherArgs{
-		KnCEConnectionArgs: nil,
-		ClientID:           "testing",
-		Brokers:            []string{"localhost:9092"},
-		TopicFunc:          utils.TopicName,
+		KnCEConnectionArgs: &kncloudevents.ConnectionArgs{
+			MaxIdleConns:        1000,
+			MaxIdleConnsPerHost: 100,
+		},
+		ClientID:  "testing",
+		Brokers:   []string{"localhost:9092"},
+		TopicFunc: utils.TopicName,
 	}
 
 	// Create the dispatcher. At this point, if Kafka is not up, this thing fails


### PR DESCRIPTION
one more backport ....  

