### PR TITLE
[0.21] Cherrypick - Use CE connection args available, instead of hardcoded values

### DIFF
--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -150,11 +150,8 @@ func NewDispatcher(ctx context.Context, args *KafkaDispatcherArgs) (*KafkaDispat
 		return nil, fmt.Errorf("unable to create kafka producer against Kafka bootstrap servers %v : %v", args.Brokers, err)
 	}
 
-	// Configured with the same connection arguments of IMC
-	kncloudevents.ConfigureConnectionArgs(&kncloudevents.ConnectionArgs{
-		MaxIdleConns:        1000,
-		MaxIdleConnsPerHost: 100,
-	})
+	// Configure connection arguments
+	kncloudevents.ConfigureConnectionArgs(args.KnCEConnectionArgs)
 
 	dispatcher := &KafkaDispatcher{
 		dispatcher:           eventingchannels.NewMessageDispatcher(logging.FromContext(ctx).Desugar()),


### PR DESCRIPTION
Cherry pick https://github.com/knative-sandbox/eventing-kafka/pull/440 into 0.21