### PR TITLE
[0.21] Adding new image for the migrator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 CGO_ENABLED=0
 GOOS=linux
 # Ignore errors if there are no images.
-CORE_IMAGES=$(shell find ./cmd -name main.go ! -path "./cmd/source/controller/*" ! -path "./cmd/channel/distributed/controller/*" ! -path "./cmd/channel/consolidated/controller/*" ! -path "./cmd/channel/consolidated/dispatcher/*" ! -path "./cmd/channel/distributed/dispatcher/*" | sed 's/main.go//')
+CORE_IMAGES=$(shell find ./cmd -name main.go ! -path "./cmd/source/controller/*" ! -path "./cmd/channel/distributed/controller/*" ! -path "./cmd/channel/consolidated/controller/*" ! -path "./cmd/channel/consolidated/dispatcher/*" ! -path "./cmd/channel/distributed/dispatcher/*" | sed 's/main.go//') ./vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate
 TEST_IMAGES=$(shell find ./test/test_images ./vendor/knative.dev/eventing/test/test_images -mindepth 1 -maxdepth 1 -type d 2> /dev/null)
 KO_DOCKER_REPO=${DOCKER_REPO_OVERRIDE}
 BRANCH=

--- a/openshift/ci-operator/knative-images/migrate/Dockerfile
+++ b/openshift/ci-operator/knative-images/migrate/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM openshift/origin-base
+
+ADD migrate /usr/bin/migrate
+ENTRYPOINT ["/usr/bin/migrate"]


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

We need to build the linux container for the "post install" job. We use the _vendored_ lib for that.
