### PR TITLE
Reflecting version change on the image promotion

### DIFF
--- a/openshift/release/knative-eventing-kafka-channel-ci.yaml
+++ b/openshift/release/knative-eventing-kafka-channel-ci.yaml
@@ -448,7 +448,7 @@ spec:
       serviceAccountName: kafka-ch-controller
       containers:
       - name: controller
-        image: registry.ci.openshift.org/openshift/knative-v0.22.0:knative-eventing-kafka-consolidated-controller
+        image: registry.ci.openshift.org/openshift/knative-v0.22.3:knative-eventing-kafka-consolidated-controller
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging
@@ -465,7 +465,7 @@ spec:
         - name: CONFIG_LEADERELECTION_NAME
           value: config-leader-election
         - name: DISPATCHER_IMAGE
-          value: registry.ci.openshift.org/openshift/knative-v0.22.0:knative-eventing-kafka-consolidated-dispatcher
+          value: registry.ci.openshift.org/openshift/knative-v0.22.3:knative-eventing-kafka-consolidated-dispatcher
         ports:
         - containerPort: 9090
           name: metrics
@@ -499,7 +499,7 @@ spec:
     spec:
       containers:
       - name: dispatcher
-        image: registry.ci.openshift.org/openshift/knative-v0.22.0:knative-eventing-kafka-consolidated-dispatcher
+        image: registry.ci.openshift.org/openshift/knative-v0.22.3:knative-eventing-kafka-consolidated-dispatcher
         env:
         - name: SYSTEM_NAMESPACE
           value: ''
@@ -612,7 +612,7 @@ spec:
       containers:
       - name: kafka-webhook
         terminationMessagePolicy: FallbackToLogsOnError
-        image: registry.ci.openshift.org/openshift/knative-v0.22.0:knative-eventing-kafka-webhook
+        image: registry.ci.openshift.org/openshift/knative-v0.22.3:knative-eventing-kafka-webhook
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/openshift/release/knative-eventing-kafka-distributed-channel-ci.yaml
+++ b/openshift/release/knative-eventing-kafka-distributed-channel-ci.yaml
@@ -468,7 +468,7 @@ spec:
       serviceAccountName: eventing-kafka-channel-controller
       containers:
       - name: eventing-kafka
-        image: registry.ci.openshift.org/openshift/knative-v0.22.0:knative-eventing-kafka-distributed-controller
+        image: registry.ci.openshift.org/openshift/knative-v0.22.3:knative-eventing-kafka-distributed-controller
         imagePullPolicy: IfNotPresent # Must be IfNotPresent or Never if used with ko.local
         ports:
         - containerPort: 8081
@@ -495,9 +495,9 @@ spec:
         - name: METRICS_DOMAIN
           value: "eventing-kafka"
         - name: RECEIVER_IMAGE
-          value: "registry.ci.openshift.org/openshift/knative-v0.22.0:knative-eventing-kafka-receiver"
+          value: "registry.ci.openshift.org/openshift/knative-v0.22.3:knative-eventing-kafka-receiver"
         - name: DISPATCHER_IMAGE
-          value: "registry.ci.openshift.org/openshift/knative-v0.22.0:knative-eventing-kafka-distributed-dispatcher"
+          value: "registry.ci.openshift.org/openshift/knative-v0.22.3:knative-eventing-kafka-distributed-dispatcher"
         resources:
           requests:
             cpu: 20m
@@ -526,7 +526,7 @@ spec:
       containers:
       - name: kafka-webhook
         terminationMessagePolicy: FallbackToLogsOnError
-        image: registry.ci.openshift.org/openshift/knative-v0.22.0:knative-eventing-kafka-webhook
+        image: registry.ci.openshift.org/openshift/knative-v0.22.3:knative-eventing-kafka-webhook
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/openshift/release/knative-eventing-kafka-source-ci.yaml
+++ b/openshift/release/knative-eventing-kafka-source-ci.yaml
@@ -341,7 +341,7 @@ spec:
       serviceAccountName: kafka-controller-manager
       containers:
       - name: manager
-        image: registry.ci.openshift.org/openshift/knative-v0.22.0:knative-eventing-kafka-source-controller
+        image: registry.ci.openshift.org/openshift/knative-v0.22.3:knative-eventing-kafka-source-controller
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -354,7 +354,7 @@ spec:
         - name: CONFIG_LEADERELECTION_NAME
           value: config-leader-election
         - name: KAFKA_RA_IMAGE
-          value: registry.ci.openshift.org/openshift/knative-v0.22.0:knative-eventing-kafka-receive-adapter
+          value: registry.ci.openshift.org/openshift/knative-v0.22.3:knative-eventing-kafka-receive-adapter
         volumeMounts:
         resources:
           requests:


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

images are now promoted as `0.22.3`, via https://github.com/openshift/release/pull/18406

/assign @aliok 