### PR TITLE
[main] adding the 4.8 version to the stash

### DIFF
--- a/openshift/ci-operator/update-ci.sh
+++ b/openshift/ci-operator/update-ci.sh
@@ -38,6 +38,7 @@ CONFIG=$CONFIGDIR/openshift-knative-eventing-kafka-release-$VERSION
 PERIODIC_CONFIG=$PERIODIC_CONFIGDIR/openshift-knative-eventing-kafka-release-$VERSION-periodics.yaml
 CURDIR=$(dirname $0)
 $CURDIR/generate-ci-config.sh knative-$VERSION 4.7 > ${CONFIG}__47.yaml
+$CURDIR/generate-ci-config.sh knative-$VERSION 4.8 true > ${CONFIG}__48.yaml
 
 # Switch to openshift/release to generate PROW files
 cd $OPENSHIFT


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

We have added the 4.8 CI runs for kafka. This PR adds those to the CI-Config generator, so we have it for future releases

