### PR TITLE
Add verbosit to create-release-branch.sh script

### DIFF
--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -2,13 +2,13 @@
 
 # Usage: create-release-branch.sh v0.4.1 release-0.4
 
-set -e # Exit immediately on error.
+set -ex # Exit immediately on error.
 
 release=$1
 target=$2
 
 # Fetch the latest tags and checkout a new branch from the wanted tag.
-git fetch upstream --tags
+git fetch upstream -v --tags
 git checkout -b "$target" "$release"
 
 # Copy the openshift extra files from the OPENSHIFT/main branch.


### PR DESCRIPTION
@matzew I think the mirroring script is failing because of the `git fetch upstream --tags` invocation on line 11 here -- it seems that the tags would get clobbered. I'm adding more verbosity here for the nightly runs to see.

I'm not sure I understand if there's any downside to updating the tags from upstream (I'm actually not entirely sure why there's a clobbering issue in general for 0.21 or 0.22 branches).  Any idea if we could add a `-f` to the `git fetch upstream --tags` line?