### PR TITLE
[Backport][Release-v0.22.0] Support eventing metrics 

### DIFF
--- a/pkg/channel/consolidated/dispatcher/consumer_message_handler.go
+++ b/pkg/channel/consolidated/dispatcher/consumer_message_handler.go
@@ -23,7 +23,6 @@ import (
 	"github.com/Shopify/sarama"
 	protocolkafka "github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2"
 	"github.com/cloudevents/sdk-go/v2/binding"
-	"github.com/cloudevents/sdk-go/v2/binding/buffering"
 	"go.uber.org/zap"
 	"knative.dev/eventing-kafka/pkg/common/consumer"
 	"knative.dev/eventing-kafka/pkg/common/tracing"
@@ -76,29 +75,21 @@ func (c consumerMessageHandler) Handle(ctx context.Context, consumerMessage *sar
 
 	te := kncloudevents.TypeExtractorTransformer("")
 
-	bufferedMessage, err := buffering.CopyMessage(ctx, message, &te)
-
-	if err != nil {
-		return false, err
-	}
-
-	args := eventingchannels.ReportArgs{
-		Ns:        c.channelNs,
-		EventType: string(te),
-	}
-
-	_ = message.Finish(nil)
-
 	dispatchExecutionInfo, err := c.dispatcher.DispatchMessageWithRetries(
 		ctx,
-		bufferedMessage,
+		message,
 		nil,
 		c.sub.Subscriber,
 		c.sub.Reply,
 		c.sub.DeadLetter,
 		c.sub.RetryConfig,
+		[]binding.Transformer{&te}...,
 	)
 
+	args := eventingchannels.ReportArgs{
+		Ns:        c.channelNs,
+		EventType: string(te),
+	}
 	_ = fanout.ParseDispatchResultAndReportMetrics(fanout.NewDispatchResult(err, dispatchExecutionInfo), c.reporter, args)
 
 	// NOTE: only return `true` here if DispatchMessage actually delivered the message.

--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-
 	"github.com/Shopify/sarama"
 	protocolkafka "github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2"
 	"github.com/cloudevents/sdk-go/v2/binding"

--- a/pkg/channel/distributed/dispatcher/dispatcher/handler.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/handler.go
@@ -153,6 +153,6 @@ func (h *Handler) consumeMessage(context context.Context, consumerMessage *saram
 	defer span.End()
 
 	// Dispatch The Message With Configured Retries & Return Any Errors
-	_, dispatchError := h.MessageDispatcher.DispatchMessageWithRetries(ctx, message, nil, destinationURL, replyURL, deadLetterURL, retryConfig)
+	_, dispatchError := h.MessageDispatcher.DispatchMessageWithRetries(ctx, message, nil, destinationURL, replyURL, deadLetterURL, retryConfig, nil)
 	return dispatchError
 }

--- a/pkg/channel/distributed/dispatcher/dispatcher/handler.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/handler.go
@@ -153,6 +153,6 @@ func (h *Handler) consumeMessage(context context.Context, consumerMessage *saram
 	defer span.End()
 
 	// Dispatch The Message With Configured Retries & Return Any Errors
-	_, dispatchError := h.MessageDispatcher.DispatchMessageWithRetries(ctx, message, nil, destinationURL, replyURL, deadLetterURL, retryConfig, nil)
+	_, dispatchError := h.MessageDispatcher.DispatchMessageWithRetries(ctx, message, nil, destinationURL, replyURL, deadLetterURL, retryConfig)
 	return dispatchError
 }

--- a/pkg/channel/distributed/dispatcher/testing/mocks.go
+++ b/pkg/channel/distributed/dispatcher/testing/mocks.go
@@ -18,6 +18,7 @@ package testing
 
 import (
 	"context"
+	"github.com/cloudevents/sdk-go/v2/binding"
 	"net/http"
 	"net/url"
 	"sync"
@@ -74,7 +75,7 @@ func (m *MockMessageDispatcher) DispatchMessage(ctx context.Context, message clo
 	panic("implement me")
 }
 
-func (m *MockMessageDispatcher) DispatchMessageWithRetries(ctx context.Context, message cloudevents.Message, headers http.Header, destinationUrl *url.URL, replyUrl *url.URL, deadLetterUrl *url.URL, retryConfig *kncloudevents.RetryConfig) (*channel.DispatchExecutionInfo, error) {
+func (m *MockMessageDispatcher) DispatchMessageWithRetries(ctx context.Context, message cloudevents.Message, headers http.Header, destinationUrl *url.URL, replyUrl *url.URL, deadLetterUrl *url.URL, retryConfig *kncloudevents.RetryConfig, transformers ...binding.Transformer) (*channel.DispatchExecutionInfo, error) {
 
 	// Validate The Expected Args
 	assert.NotNil(m.t, ctx)

--- a/vendor/knative.dev/eventing/pkg/channel/fanout/fanout_message_handler.go
+++ b/vendor/knative.dev/eventing/pkg/channel/fanout/fanout_message_handler.go
@@ -190,7 +190,7 @@ func createMessageReceiverFunction(f *FanoutMessageHandler) func(context.Context
 				ctx = trace.NewContext(context.Background(), s)
 				// Any returned error is already logged in f.dispatch().
 				dispatchResultForFanout := f.dispatch(ctx, subs, m, h)
-				_ = parseFanoutResultAndReportMetrics(dispatchResultForFanout, *r, *args)
+				_ = ParseDispatchResultAndReportMetrics(dispatchResultForFanout, *r, *args)
 			}(bufferedMessage, additionalHeaders, parentSpan, &f.reporter, &reportArgs)
 			return nil
 		}
@@ -217,7 +217,7 @@ func createMessageReceiverFunction(f *FanoutMessageHandler) func(context.Context
 		reportArgs.EventType = string(te)
 		reportArgs.Ns = ref.Namespace
 		dispatchResultForFanout := f.dispatch(ctx, subs, bufferedMessage, additionalHeaders)
-		return parseFanoutResultAndReportMetrics(dispatchResultForFanout, f.reporter, reportArgs)
+		return ParseDispatchResultAndReportMetrics(dispatchResultForFanout, f.reporter, reportArgs)
 	}
 }
 
@@ -225,7 +225,8 @@ func (f *FanoutMessageHandler) ServeHTTP(response nethttp.ResponseWriter, reques
 	f.receiver.ServeHTTP(response, request)
 }
 
-func parseFanoutResultAndReportMetrics(result dispatchResult, reporter channel.StatsReporter, reportArgs channel.ReportArgs) error {
+// ParseDispatchResultAndReportMetric processes the dispatch result and records the related channel metrics with the appropriate context
+func ParseDispatchResultAndReportMetrics(result DispatchResult, reporter channel.StatsReporter, reportArgs channel.ReportArgs) error {
 	if result.info != nil && result.info.Time > channel.NoDuration {
 		if result.info.ResponseCode > channel.NoResponse {
 			_ = reporter.ReportEventDispatchTime(&reportArgs, result.info.ResponseCode, result.info.Time)
@@ -244,20 +245,19 @@ func parseFanoutResultAndReportMetrics(result dispatchResult, reporter channel.S
 
 // dispatch takes the event, fans it out to each subscription in subs. If all the fanned out
 // events return successfully, then return nil. Else, return an error.
-func (f *FanoutMessageHandler) dispatch(ctx context.Context, subs []Subscription, bufferedMessage binding.Message, additionalHeaders nethttp.Header) dispatchResult {
-	// Bind the lifecycle of the buffered message to the number of subs
+func (f *FanoutMessageHandler) dispatch(ctx context.Context, subs []Subscription, bufferedMessage binding.Message, additionalHeaders nethttp.Header) DispatchResult {	// Bind the lifecycle of the buffered message to the number of subs
 	bufferedMessage = buffering.WithAcksBeforeFinish(bufferedMessage, len(subs))
 
-	errorCh := make(chan dispatchResult, len(subs))
+	errorCh := make(chan DispatchResult, len(subs))
 	for _, sub := range subs {
 		go func(s Subscription) {
 			dispatchedResultPerSub, err := f.makeFanoutRequest(ctx, bufferedMessage, additionalHeaders, s)
-			errorCh <- dispatchResult{err: err, info: dispatchedResultPerSub}
+			errorCh <- DispatchResult{err: err, info: dispatchedResultPerSub}
 		}(sub)
 	}
 
 	var totalDispatchTimeForFanout time.Duration = channel.NoDuration
-	dispatchResultForFanout := dispatchResult{
+	dispatchResultForFanout := DispatchResult{
 		info: &channel.DispatchExecutionInfo{
 			Time:         channel.NoDuration,
 			ResponseCode: channel.NoResponse,
@@ -306,7 +306,23 @@ func (f *FanoutMessageHandler) makeFanoutRequest(ctx context.Context, message bi
 	)
 }
 
-type dispatchResult struct {
+type DispatchResult struct {
 	err  error
 	info *channel.DispatchExecutionInfo
 }
+
+func (d DispatchResult) Error() error {
+	return d.err
+}
+
+func (d DispatchResult) Info() *channel.DispatchExecutionInfo {
+	return d.info
+}
+
+func NewDispatchResult(err error, info *channel.DispatchExecutionInfo) DispatchResult {
+	return DispatchResult{
+		err:  err,
+		info: info,
+	}
+}
+

--- a/vendor/knative.dev/eventing/pkg/channel/fanout/fanout_message_handler.go
+++ b/vendor/knative.dev/eventing/pkg/channel/fanout/fanout_message_handler.go
@@ -303,7 +303,6 @@ func (f *FanoutMessageHandler) makeFanoutRequest(ctx context.Context, message bi
 		sub.Reply,
 		sub.DeadLetter,
 		sub.RetryConfig,
-		nil,
 	)
 }
 

--- a/vendor/knative.dev/eventing/pkg/channel/fanout/fanout_message_handler.go
+++ b/vendor/knative.dev/eventing/pkg/channel/fanout/fanout_message_handler.go
@@ -303,6 +303,7 @@ func (f *FanoutMessageHandler) makeFanoutRequest(ctx context.Context, message bi
 		sub.Reply,
 		sub.DeadLetter,
 		sub.RetryConfig,
+		nil,
 	)
 }
 

--- a/vendor/knative.dev/eventing/pkg/channel/message_dispatcher.go
+++ b/vendor/knative.dev/eventing/pkg/channel/message_dispatcher.go
@@ -122,8 +122,8 @@ func (d *MessageDispatcherImpl) DispatchMessageWithRetries(ctx context.Context, 
 		if err != nil {
 			// If DeadLetter is configured, then send original message with knative error extensions
 			if deadLetter != nil {
-				transformers := d.dispatchExecutionInfoTransformers(dispatchExecutionInfo)
-				_, deadLetterResponse, _, dispatchExecutionInfo, deadLetterErr := d.executeRequest(ctx, deadLetter, message, additionalHeaders, retriesConfig, transformers...)
+				dipatchTransformers := d.dispatchExecutionInfoTransformers(dispatchExecutionInfo)
+				_, deadLetterResponse, _, dispatchExecutionInfo, deadLetterErr := d.executeRequest(ctx, deadLetter, message, additionalHeaders, retriesConfig, append(transformers, dipatchTransformers)...)
 				if deadLetterErr != nil {
 					return dispatchExecutionInfo, fmt.Errorf("unable to complete request to either %s (%v) or %s (%v)", destination, err, deadLetter, deadLetterErr)
 				}
@@ -154,12 +154,12 @@ func (d *MessageDispatcherImpl) DispatchMessageWithRetries(ctx context.Context, 
 		return dispatchExecutionInfo, nil
 	}
 
-	ctx, responseResponseMessage, _, dispatchExecutionInfo, err := d.executeRequest(ctx, reply, responseMessage, responseAdditionalHeaders, retriesConfig)
+	ctx, responseResponseMessage, _, dispatchExecutionInfo, err := d.executeRequest(ctx, reply, responseMessage, responseAdditionalHeaders, retriesConfig, transformers...)
 	if err != nil {
 		// If DeadLetter is configured, then send original message with knative error extensions
 		if deadLetter != nil {
-			transformers := d.dispatchExecutionInfoTransformers(dispatchExecutionInfo)
-			_, deadLetterResponse, _, dispatchExecutionInfo, deadLetterErr := d.executeRequest(ctx, deadLetter, message, responseAdditionalHeaders, retriesConfig, transformers...)
+			dispatchTransformers := d.dispatchExecutionInfoTransformers(dispatchExecutionInfo)
+			_, deadLetterResponse, _, dispatchExecutionInfo, deadLetterErr := d.executeRequest(ctx, deadLetter, message, responseAdditionalHeaders, retriesConfig, append(transformers, dispatchTransformers)...)
 			if deadLetterErr != nil {
 				return dispatchExecutionInfo, fmt.Errorf("failed to forward reply to %s (%v) and failed to send it to the dead letter sink %s (%v)", reply, err, deadLetter, deadLetterErr)
 			}

--- a/vendor/knative.dev/eventing/pkg/channel/stats_reporter.go
+++ b/vendor/knative.dev/eventing/pkg/channel/stats_reporter.go
@@ -30,19 +30,19 @@ import (
 )
 
 var (
-	// eventCountM is a counter which records the number of events received
-	// by the in-memory Channel.
+	// eventCountM is a counter which records the number of events dispatched
+	// by the channel.
 	eventCountM = stats.Int64(
 		"event_count",
-		"Number of events dispatched by the in-memory channel",
+		"Number of events dispatched by the channel",
 		stats.UnitDimensionless,
 	)
 
-	// dispatchTimeInMsecM records the Time spent dispatching an event to
-	// a Channel, in milliseconds.
+	// dispatchTimeInMsecM records the time spent by the channel dispatching an event to
+	// to subscribers, in milliseconds.
 	dispatchTimeInMsecM = stats.Float64(
 		"event_dispatch_latencies",
-		"The Time spent dispatching an event from a in-memoryChannel",
+		"The time spent by the channel dispatching an event",
 		stats.UnitMilliseconds,
 	)
 


### PR DESCRIPTION
Backport: https://github.com/knative-sandbox/eventing-kafka/pull/688
To be completely aligned opened: https://github.com/openshift/knative-eventing/pull/1311
My goal is to add visualizations for channel metrics at the S-O side.
/cc @aliok @matzew 

I am also planning to backport for 0.23. Didnt go upstream because afaik we depend on the release tag there.