### PR TITLE
[0.22] Remove depracted test

### DIFF
--- a/test/e2e/kafka_binding_test.go
+++ b/test/e2e/kafka_binding_test.go
@@ -144,9 +144,6 @@ func TestKafkaBinding(t *testing.T) {
 	}
 	for name, tc := range tests {
 		tc := tc
-		t.Run(name+"-v1alpha1", func(t *testing.T) {
-			testKafkaBinding(t, "v1alpha1", tc.messageKey, tc.messageHeaders, tc.messagePayload, tc.expectedData)
-		})
 		t.Run(name+"-v1beta1", func(t *testing.T) {
 			testKafkaBinding(t, "v1beta1", tc.messageKey, tc.messageHeaders, tc.messagePayload, tc.expectedData)
 		})


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

we do not care about the `v1alpha1` anyways - it's also already removed, upstream