### PR TITLE
Remove patching non-existent KnativeEventing

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -336,8 +336,7 @@ function run_e2e_tests(){
   # the source tests REQUIRE the secrets, hence we create it here:
   create_auth_secrets || return 1
 
-  oc get ns ${SYSTEM_NAMESPACE} 2>/dev/null || SYSTEM_NAMESPACE="knative-eventing"
-  oc -n ${SYSTEM_NAMESPACE} patch knativeeventing/knative-eventing --type=merge --patch='{"spec": {"config": { "tracing": {"enable":"true","backend":"zipkin", "zipkin-endpoint":"http://zipkin.'${SYSTEM_NAMESPACE}'.svc.cluster.local:9411/api/v2/spans", "debug":"true", "sample-rate":"1.0"}}}}'
+  oc get ns "${SYSTEM_NAMESPACE}" 2>/dev/null || SYSTEM_NAMESPACE="knative-eventing"
 
   local test_name="${1:-}"
   local run_command=""


### PR DESCRIPTION
This patching has no effect in this repository because KnativeEventing
is not used here. However, it causes problems when running the tests
from serverless-operator repo where KnativeEventing IS used and Tracing
is installed in different namespace (istio-system). Applying this patch
would change KnativeEventing configuration to expect Tracing in
knative-eventing NS which is wrong.

The patch is currently not effective, the previous runs show this error:
+ oc -n knative-eventing patch knativeeventing/knative-eventing
--type=merge '--patch={"spec": {"config": { "tracing":
{"enable":"true","backend":"zipkin",
"zipkin-endpoint":"http://zipkin.knative-eventing.svc.cluster.local:9411/api/v2/spans",
"debug":"true", "sample-rate":"1.0"}}}}'
Error from server (NotFound): knativeeventings.operator.knative.dev
"knative-eventing" not found