### PR TITLE
[main] Patch knative-eventing with tracing config when installing tracing (#…

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -83,6 +83,7 @@ function install_tracing() {
   echo "Installing Zipkin..."
   sed "s/\${SYSTEM_NAMESPACE}/${SYSTEM_NAMESPACE}/g" < "${KNATIVE_EVENTING_MONITORING_YAML}" | oc apply -f -
   wait_until_pods_running "${SYSTEM_NAMESPACE}" || fail_test "Zipkin inside eventing did not come up"
+  oc -n "${SYSTEM_NAMESPACE}" patch knativeeventing/knative-eventing --type=merge --patch='{"spec": {"config": { "tracing": {"enable":"true","backend":"zipkin", "zipkin-endpoint":"http://zipkin.'${SYSTEM_NAMESPACE}'.svc.cluster.local:9411/api/v2/spans", "debug":"true", "sample-rate":"1.0"}}}}'
 }
 
 function install_strimzi(){
@@ -335,9 +336,6 @@ function run_e2e_tests(){
 
   # the source tests REQUIRE the secrets, hence we create it here:
   create_auth_secrets || return 1
-
-  oc get ns ${SYSTEM_NAMESPACE} 2>/dev/null || SYSTEM_NAMESPACE="knative-eventing"
-  oc -n ${SYSTEM_NAMESPACE} patch knativeeventing/knative-eventing --type=merge --patch='{"spec": {"config": { "tracing": {"enable":"true","backend":"zipkin", "zipkin-endpoint":"http://zipkin.'${SYSTEM_NAMESPACE}'.svc.cluster.local:9411/api/v2/spans", "debug":"true", "sample-rate":"1.0"}}}}'
 
   local test_name="${1:-}"
   local run_command=""


### PR DESCRIPTION
…626)

The goal is to move patching the knativeeventing resource from
run_e2e_tests to install_tracing and better separate installation from
running E2E tests.
The run_e2e_tests function is reused in serverless-operator repo and
there we might install tracing earlier. Patching the knativeeventing
resource at that point brakes the installation.
The run_e2e_tests function should really just run tests and not change
product installation.

Co-authored-by: Martin Gencur <mgencur@redhat.com>