### PR TITLE
[release-v1.4] Allow Restricted Pod Security Standard for test pods

### DIFF
--- a/vendor/knative.dev/eventing/test/lib/creation.go
+++ b/vendor/knative.dev/eventing/test/lib/creation.go
@@ -32,6 +32,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/reconciler"
 	pkgtest "knative.dev/pkg/test"
+	pkgsecurity "knative.dev/pkg/test/security"
 
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	flowsv1 "knative.dev/eventing/pkg/apis/flows/v1"
@@ -427,6 +428,8 @@ func (c *Client) CreatePodOrFail(pod *corev1.Pod, options ...func(*corev1.Pod, *
 			c.T.Fatalf("Failed to configure pod %q: %v", pod.Name, err)
 		}
 	}
+
+	pkgsecurity.AllowRestrictedPodSecurityStandard(context.Background(), c.Kube, pod)
 
 	c.applyAdditionalEnv(&pod.Spec)
 

--- a/vendor/knative.dev/pkg/test/security/security.go
+++ b/vendor/knative.dev/pkg/test/security/security.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package security
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"knative.dev/pkg/ptr"
+)
+
+var DefaultPodSecurityContext = corev1.PodSecurityContext{
+	RunAsNonRoot: ptr.Bool(true),
+	SeccompProfile: &corev1.SeccompProfile{
+		Type: corev1.SeccompProfileTypeRuntimeDefault,
+	},
+}
+
+var DefaultContainerSecurityContext = corev1.SecurityContext{
+	AllowPrivilegeEscalation: ptr.Bool(false),
+	Capabilities: &corev1.Capabilities{
+		Drop: []corev1.Capability{"ALL"},
+	},
+}
+
+// AllowRestrictedPodSecurityStandard adds SecurityContext to Pod and its containers so that it can run
+// in a namespace with enforced "restricted" security standard.
+func AllowRestrictedPodSecurityStandard(ctx context.Context, kubeClient kubernetes.Interface, pod *corev1.Pod) error {
+	enforced, err := IsRestrictedPodSecurityEnforced(ctx, kubeClient, pod.Namespace)
+	if err != nil {
+		return err
+	}
+	if enforced {
+		pod.Spec.SecurityContext = &DefaultPodSecurityContext
+		for _, c := range pod.Spec.Containers {
+			c.SecurityContext = &DefaultContainerSecurityContext
+		}
+	}
+	return nil
+}
+
+// IsRestrictedPodSecurityEnforced checks if the given namespace has enforced restricted security standard.
+func IsRestrictedPodSecurityEnforced(ctx context.Context, kubeClient kubernetes.Interface, namespace string) (bool, error) {
+	ns, err := kubeClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	for k, v := range ns.Labels {
+		if k == "pod-security.kubernetes.io/enforce" && v == "restricted" {
+			return true, nil
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
This is a subset of https://github.com/openshift/knative-eventing/pull/1910 . We don't need changes for rekt tests as they're not used in eventing-kafka.

eventing-kafka repo is still used in serverless-operator upgrade tests and it needs to run on OCP 4.12. So, I'm sending the changes here and then will update dependencies in serverless-operator.